### PR TITLE
Added async to ClientProxy

### DIFF
--- a/shared/main/scala/autowire/package.scala
+++ b/shared/main/scala/autowire/package.scala
@@ -18,6 +18,7 @@ package object autowire {
 
   class ClientProxy[T, A](h: Client[A]){
     def apply[R: upickle.Reader](f: T => R): Future[R] = macro Macros.ajaxMacro[R]
+    def async[R: upickle.Reader](f: T => Future[R]): Future[R] = macro Macros.ajaxMacro[R]
     def callRequest(req: Request): Future[String] = h.callRequest(req)
   }
 

--- a/shared/test/scala/autowire/Tests.scala
+++ b/shared/test/scala/autowire/Tests.scala
@@ -65,10 +65,10 @@ object Tests extends TestSuite{
       val res = await(api(_.add(1, 2, 4)))
       assert(res == "1+2+4")
     }
-//    'async{
-//      val res5 = await(Client[Api](_.sloww(Seq("omgomg", "wtf"))))
-//      assert(res5 == Seq(6, 3))
-//    }
+    'async{
+      val res5 = await(Client[Api].async(_.sloww(Seq("omgomg", "wtf"))))
+      assert(res5 == Seq(6, 3))
+    }
     'compilationFailures{
       'notWebFails{
         import shapeless.test.illTyped


### PR DESCRIPTION
Turns out I don't need to learn macros quite yet... from what I can gather, the futurize function inside of the macro already effectively solves passing a future, so we can just reuse the macro as is.

Creating an async function and using it in the test code appears to work.

I did attempt to rename async to apply, and encountered a type inference problem:

```
autowire/Tests.scala:69: missing parameter type for expanded function ((x$9) => x$9.sloww(Seq("omgomg", "wtf")))
[error]       val res5 = await(Client[Api](_.sloww(Seq("omgomg", "wtf"))))
```

Changing the line to the following fixes the issue and it does run...

```
val res5 = await(Client[Api]((_:Api).sloww(Seq("omgomg", "wtf"))))
```

But I had to add the :Api annotation to all the other uses of Client[Api]...

I have no idea why the compiler complains about inferring the type of _ in this case. Therefore, I have currently left in the async instead of trying to add another apply method.
