### PR TITLE
routeMacro refactoring

### DIFF
--- a/autowire/shared/src/main/scala/autowire/ClientServer.scala
+++ b/autowire/shared/src/main/scala/autowire/ClientServer.scala
@@ -45,7 +45,7 @@ trait Server[PickleType, Reader[_], Writer[_]] extends Serializers[PickleType, R
    * A macro that generates a `Router` PartialFunction which will dispatch incoming
    * [[Requests]] to the relevant method on [[Trait]]
    */
-  def route[Trait](target: Trait): Router = macro Macros.routeMacro[Trait, PickleType]
+  def route[Trait](target: Trait): Router = macro Macros.routeMacro2[Trait, PickleType]
 
 }
 

--- a/autowire/shared/src/main/scala/autowire/ClientServer.scala
+++ b/autowire/shared/src/main/scala/autowire/ClientServer.scala
@@ -45,7 +45,7 @@ trait Server[PickleType, Reader[_], Writer[_]] extends Serializers[PickleType, R
    * A macro that generates a `Router` PartialFunction which will dispatch incoming
    * [[Requests]] to the relevant method on [[Trait]]
    */
-  def route[Trait](target: Trait): Router = macro Macros.routeMacro2[Trait, PickleType]
+  def route[Trait](target: Trait): Router = macro Macros.routeMacro[Trait, PickleType]
 
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,9 +3,9 @@ crossScalaVersions := Seq("2.10.4", "2.11.4")
 val autowire = crossProject.settings(
   organization := "com.lihaoyi",
 
-  version := "0.2.5",
+  version := "0.2.6-SNAPSHOT",
   name := "autowire",
-  scalaVersion := "2.10.4",
+  scalaVersion := "2.11.7",
   autoCompilerPlugins := true,
   addCompilerPlugin("com.lihaoyi" %% "acyclic" % "0.1.2"),
   libraryDependencies ++= Seq(

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.5")
 
 


### PR DESCRIPTION
This changes routeMacro to use a tree based datastructure, hopefully avoiding a JVM limitation when a method gets too large. In theory its also higher performant, but I haven't done any empirical testing. 