### PR TITLE
Remove package check.

### DIFF
--- a/autowire/shared/src/main/scala/autowire/Macros.scala
+++ b/autowire/shared/src/main/scala/autowire/Macros.scala
@@ -159,10 +159,6 @@ object Macros {
       }
     }
     val res = for {
-      q"${Pkg(_)}.`package`.$callableName[$t]($contents)" <- Win(c.prefix.tree,
-        "You can only use .call() on the Proxy returned by autowire.Client.apply, not " + c.prefix.tree
-      )
-      if Seq("clientFutureCallable", "clientCallable").contains(callableName.toString)
       // If the tree is one of those default-argument containing blocks or
       // functions, pry it apart such that the main logic can operate on the
       // inner tree, and leave instructions on how


### PR DESCRIPTION
Hi, 

I am using your library to do a specific RPC library for my own purposes, and problem that I cannot hide autowire specific stuff due to restriction for .call of separate package created proxy.

Is it possible to remove that restriction?