### PR TITLE
Update dependency versions

### DIFF
--- a/autowire/jvm/src/test/scala/autowire/InteropTests.scala
+++ b/autowire/jvm/src/test/scala/autowire/InteropTests.scala
@@ -2,9 +2,9 @@ package autowire
 import utest._
 import scala.concurrent.Future
 import java.io.{ObjectInputStream, ByteArrayInputStream, ObjectOutputStream, ByteArrayOutputStream}
-import utest.util.Tree
+import utest.framework.Tree
 import utest.framework.Test
-import utest.ExecutionContext.RunNow
+import utest.framework.ExecutionContext.RunNow
 import scala.reflect.ClassTag
 import utest._
 import scala.pickling._

--- a/autowire/shared/src/test/scala/autowire/CompileTimeOnlyTests.scala
+++ b/autowire/shared/src/test/scala/autowire/CompileTimeOnlyTests.scala
@@ -4,16 +4,16 @@ import scala.concurrent.Future
 import autowire._
 import scala.util.Properties
 import utest._
-import upickle._
+import upickle.default._
 import autowire._
 
 //This test should only be run in 2.11+ since 2.10 will not enforce this annotation
 object CompileTimeOnlyTests extends TestSuite{
   import scala.concurrent.ExecutionContext.Implicits.global
   // client-side implementation, and call-site
-  object MyClient extends autowire.Client[String, upickle.Reader, upickle.Writer]{
-    def write[Result: Writer](r: Result) = upickle.write(r)
-    def read[Result: Reader](p: String) = upickle.read[Result](p)
+  object MyClient extends autowire.Client[String, upickle.default.Reader, upickle.default.Writer]{
+    def write[Result: Writer](r: Result) = upickle.default.write(r)
+    def read[Result: Reader](p: String) = upickle.default.read[Result](p)
     override def doCall(req: Request) = {
       Future(req.args("x"))
     }

--- a/autowire/shared/src/test/scala/autowire/RelativeRoutingTests.scala
+++ b/autowire/shared/src/test/scala/autowire/RelativeRoutingTests.scala
@@ -2,8 +2,9 @@ package autowire
 
 import java.io.File
 import utest._
-import utest.ExecutionContext.RunNow
-import upickle._
+import utest.framework._
+import utest.framework.ExecutionContext.RunNow
+import upickle.default._
 import acyclic.file
 
 
@@ -43,17 +44,17 @@ object RelativeRoutingTests extends TestSuite {
       }
 
 
-      trait UPickleSerializers extends Serializers[String, upickle.Reader, upickle.Writer] {
-        override def write[Result: Writer](r: Result) = upickle.write(r)
-        override def read[Result: Reader](p: String) = upickle.read[Result](p)
+      trait UPickleSerializers extends Serializers[String, upickle.default.Reader, upickle.default.Writer] {
+        override def write[Result: Writer](r: Result) = upickle.default.write(r)
+        override def read[Result: Reader](p: String) = upickle.default.read[Result](p)
       }
 
-      object UPickleServer extends autowire.Server[String, upickle.Reader, upickle.Writer] with UPickleSerializers
+      object UPickleServer extends autowire.Server[String, upickle.default.Reader, upickle.default.Writer] with UPickleSerializers
       val x = new MyApiImpl("aa")
       val router = UPickleServer.route[MagicalApi](x)
 
       // client-side implementation, and call-site
-      object MyClient extends autowire.Client[String, upickle.Reader, upickle.Writer] with UPickleSerializers {
+      object MyClient extends autowire.Client[String, upickle.default.Reader, upickle.default.Writer] with UPickleSerializers {
         override def doCall(req: Request) = {
           router(req)
         }

--- a/autowire/shared/src/test/scala/autowire/UpickleTests.scala
+++ b/autowire/shared/src/test/scala/autowire/UpickleTests.scala
@@ -1,14 +1,16 @@
 package autowire
 import utest._
-import utest.ExecutionContext.RunNow
-import upickle._
+import utest.framework._
+import utest.framework.ExecutionContext.RunNow
+import upickle.Js
+import upickle.default._
 import acyclic.file
 
 
 object UpickleTests extends TestSuite{
-  object Bundle extends GenericClientServerBundle[String, upickle.Reader, upickle.Writer]{
-    def write[T: upickle.Writer](t: T) = upickle.write(t)
-    def read[T: upickle.Reader](t: String) = upickle.read[T](t)
+  object Bundle extends GenericClientServerBundle[String, upickle.default.Reader, upickle.default.Writer]{
+    def write[T: upickle.default.Writer](t: T) = upickle.default.write(t)
+    def read[T: upickle.default.Reader](t: String) = upickle.default.read[T](t)
     def routes = Server.route[Api](Controller)
   }
   import Bundle.{Client, Server}
@@ -28,17 +30,17 @@ object UpickleTests extends TestSuite{
       object MyApiImpl extends MyApi{
         def doThing(i: Int, s: String) = Seq.fill(i)(s)
       }
-      object MyServer extends autowire.Server[String, upickle.Reader, upickle.Writer]{
-        def write[Result: Writer](r: Result) = upickle.write(r)
-        def read[Result: Reader](p: String) = upickle.read[Result](p)
+      object MyServer extends autowire.Server[String, upickle.default.Reader, upickle.default.Writer]{
+        def write[Result: Writer](r: Result) = upickle.default.write(r)
+        def read[Result: Reader](p: String) = upickle.default.read[Result](p)
 
         val routes = MyServer.route[MyApi](MyApiImpl)
       }
 
       // client-side implementation, and call-site
-      object MyClient extends autowire.Client[String, upickle.Reader, upickle.Writer]{
-        def write[Result: Writer](r: Result) = upickle.write(r)
-        def read[Result: Reader](p: String) = upickle.read[Result](p)
+      object MyClient extends autowire.Client[String, upickle.default.Reader, upickle.default.Writer]{
+        def write[Result: Writer](r: Result) = upickle.default.write(r)
+        def read[Result: Reader](p: String) = upickle.default.read[Result](p)
 
         override def doCall(req: Request) = {
           println(req)
@@ -77,16 +79,16 @@ object UpickleTests extends TestSuite{
         with BookController
         with ArticleController
 
-      object MyServer extends autowire.Server[String, upickle.Reader, upickle.Writer]{
-        def write[Result: Writer](r: Result) = upickle.write(r)
-        def read[Result: Reader](p: String) = upickle.read[Result](p)
+      object MyServer extends autowire.Server[String, upickle.default.Reader, upickle.default.Writer]{
+        def write[Result: Writer](r: Result) = upickle.default.write(r)
+        def read[Result: Reader](p: String) = upickle.default.read[Result](p)
 
         val routes = MyServer.route[Protocol](Controller)
       }
 
-      object MyClient extends autowire.Client[String, upickle.Reader, upickle.Writer]{
-        def write[Result: Writer](r: Result) = upickle.write(r)
-        def read[Result: Reader](p: String) = upickle.read[Result](p)
+      object MyClient extends autowire.Client[String, upickle.default.Reader, upickle.default.Writer]{
+        def write[Result: Writer](r: Result) = upickle.default.write(r)
+        def read[Result: Reader](p: String) = upickle.default.read[Result](p)
 
         override def doCall(req: Request) = {
           println(req)
@@ -250,9 +252,9 @@ object UpickleTests extends TestSuite{
         def doThingTwo(i: Int, s: String) = Seq.fill(i)(s+meaningOfLife.toString)
       }
 
-      object MyServer extends autowire.Server[String, upickle.Reader, upickle.Writer]{
-        def write[Result: Writer](r: Result) = upickle.write(r)
-        def read[Result: Reader](p: String) = upickle.read[Result](p)
+      object MyServer extends autowire.Server[String, upickle.default.Reader, upickle.default.Writer]{
+        def write[Result: Writer](r: Result) = upickle.default.write(r)
+        def read[Result: Reader](p: String) = upickle.default.read[Result](p)
 
         val routes1 = MyServer.route[MyApi](new MyOtherApiImpl(42))
 
@@ -262,9 +264,9 @@ object UpickleTests extends TestSuite{
         def anApiDef(inp: Int) = new MyOtherApiImpl(inp)
         val routes3 = MyServer.route[MyApi](anApiDef(2))
       }
-      class UpickleClient(pf: PartialFunction[MyServer.Request, concurrent.Future[String]]) extends autowire.Client[String, upickle.Reader, upickle.Writer]{
-        def write[Result: Writer](r: Result) = upickle.write(r)
-        def read[Result: Reader](p: String) = upickle.read[Result](p)
+      class UpickleClient(pf: PartialFunction[MyServer.Request, concurrent.Future[String]]) extends autowire.Client[String, upickle.default.Reader, upickle.default.Writer]{
+        def write[Result: Writer](r: Result) = upickle.default.write(r)
+        def read[Result: Reader](p: String) = upickle.default.read[Result](p)
         def doCall(req: Request) = pf(req)
       }
       object Client1 extends UpickleClient(MyServer.routes1)

--- a/build.sbt
+++ b/build.sbt
@@ -1,18 +1,18 @@
-crossScalaVersions := Seq("2.10.4", "2.11.4")
+crossScalaVersions := Seq("2.10.4", "2.11.8")
 
 val autowire = crossProject.settings(
   organization := "com.lihaoyi",
 
   version := "0.2.5",
   name := "autowire",
-  scalaVersion := "2.10.4",
+  scalaVersion := "2.11.8",
   autoCompilerPlugins := true,
-  addCompilerPlugin("com.lihaoyi" %% "acyclic" % "0.1.2"),
+  addCompilerPlugin("com.lihaoyi" %% "acyclic" % "0.1.4"),
   libraryDependencies ++= Seq(
-    "com.lihaoyi" %% "acyclic" % "0.1.2" % "provided",
-    "com.lihaoyi" %%% "utest" % "0.3.1" % "test",
+    "com.lihaoyi" %% "acyclic" % "0.1.4" % "provided",
+    "com.lihaoyi" %%% "utest" % "0.4.3" % "test",
     "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-    "com.lihaoyi" %%% "upickle" % "0.2.6" % "test"
+    "com.lihaoyi" %%% "upickle" % "0.4.1" % "test"
   ) ++ (
     if (scalaVersion.value startsWith "2.11.") Nil
     else Seq(
@@ -21,15 +21,6 @@ val autowire = crossProject.settings(
     )
     ),
   testFrameworks += new TestFramework("utest.runner.Framework"),
-  unmanagedSourceDirectories in Compile ++= {
-    if (scalaVersion.value startsWith "2.10.") Seq(baseDirectory.value / ".."/"shared"/"src"/ "main" / "scala-2.10")
-    else Seq(baseDirectory.value / ".."/"shared" / "src"/"main" / "scala-2.11")
-  },
-  //Vary compileTimeOnly based on scala version
-  unmanagedSourceDirectories in Compile ++= {
-    if (scalaVersion.value startsWith "2.10.") Seq(baseDirectory.value / "shared" / "main" / "scala-2.10")
-    else Seq(baseDirectory.value /".."/ "shared"/"src"/"main"/ "scala-2.11")
-  },
   // Sonatype
   publishArtifact in Test := false,
   publishTo := Some("releases"  at "https://oss.sonatype.org/service/local/staging/deploy/maven2"),
@@ -61,9 +52,9 @@ val autowire = crossProject.settings(
 ).jvmSettings(
   resolvers += "Typesafe Repo" at "http://repo.typesafe.com/typesafe/releases/",
   libraryDependencies ++= Seq(
-    "org.scala-lang" %% "scala-pickling" % "0.9.0" % "test",
+    "org.scala-lang" %% "scala-pickling" % "0.9.1" % "test",
     "com.esotericsoftware.kryo" % "kryo" % "2.24.0" % "test",
-    "com.typesafe.play" %% "play-json" % "2.3.0" % "test"
+    "com.typesafe.play" %% "play-json" % "2.4.8" % "test"
   )
 )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.12

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.11")
 
 


### PR DESCRIPTION
Version changes:
  * sbt: 0.13.7 -> 0.13.12
  * scala 2.11: 2.11.4 -> 2.11.8
  * scalajs (sbt plugin and libraries): 0.6.1 -> 0.6.11
  * acyclic (compile-time): 0.1.2 -> 0.1.4
  * utest (for testing): 0.3.1 -> 0.4.3
  * upickle (for testing): 0.2.6 -> 0.4.1
  * scala pickling (for testing): 0.9.0 -> 0.9.1
  * play-json (for testing): 2.3.0 -> 2.4.8 (last 2.10 release)

Notes:
  * I changed the default Scala version to 2.11.8, as I think almost
    anyone who would ever clone this repo would prefer that at this
    point
  * sbt now adds Scala-version-specific unmanged source directories
    (e.g. src/scala-2.11) on its own, so I removed those from the build
    (otherwise it finds the source files twice and the build breaks)
  * The only code change I had to make was to update a bunch of names
    (mostly in tests) due to stuff being rearranged package-wise in
    upstream libraries