### PR TITLE
You can assign Client[Api] to a variable

### DIFF
--- a/autowire/shared/src/test/scala/autowire/RelativeRoutingTests.scala
+++ b/autowire/shared/src/test/scala/autowire/RelativeRoutingTests.scala
@@ -60,8 +60,10 @@ object RelativeRoutingTests extends TestSuite {
         }
       }
 
-      val a = await(MyClient[MagicalApi].shuffle(3, "lol").call())
-      val b = await(MyClient[MagicalApi].table.getHand("Ben").call())
+      val client = MyClient[MagicalApi]
+
+      val a = await(client.shuffle(3, "lol").call())
+      val b = await(client.table.getHand("Ben").call())
 
       assert("3:lol:Foo" == a)
       assert(goodHand == b)


### PR DESCRIPTION
Looks like emacs also cleaned up some whitespace. Should I split that into a separate commit?