### PR TITLE
add ExecutionContext to .call signature

### DIFF
--- a/autowire/shared/src/main/scala/autowire/Internal.scala
+++ b/autowire/shared/src/main/scala/autowire/Internal.scala
@@ -1,7 +1,7 @@
 package autowire
 
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import language.experimental.macros
 
 
@@ -16,16 +16,16 @@ object Internal{
    * call-Future extension method a chance to run first
    */
   trait LowPri {
-    implicit def clientCallable[T](t: T) = new Internal.ClientCallable[T]
+    implicit def clientCallable[T](t: T): ClientCallable[T] = new Internal.ClientCallable[T]
   }
 
   /**
    * A synthetic type purely meant to hold the `.call()` macro; gets
    * erased completely when the macro-implementation of `.call()` runs
    */
-  class ClientCallable[T]{
+  class ClientCallable[T] {
     @ScalaVersionStubs.compileTimeOnly(".call() method is synthetic and should not be used directly")
-    def call(): Future[T] = macro Macros.clientMacro[T]
+    def call()(implicit ec: ExecutionContext): Future[T] = macro Macros.clientMacro[T]
   }
 
   type FailMaybe = Either[Error.Param, Any]

--- a/autowire/shared/src/main/scala/autowire/Macros.scala
+++ b/autowire/shared/src/main/scala/autowire/Macros.scala
@@ -1,10 +1,9 @@
 package autowire
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.reflect.macros.Context
 import language.experimental.macros
 import acyclic.file
-
 import Core._
 
 object Macros {
@@ -145,9 +144,8 @@ object Macros {
   }
 
 
-  def clientMacro[Result]
-                 (c: Context)
-                 ()
+  def clientMacro[Result](c: Context)
+                 ()(ec: c.Expr[ExecutionContext])
                  (implicit r: c.WeakTypeTag[Result])
                  : c.Expr[Future[Result]] = {
 


### PR DESCRIPTION
3 tests fail on my system, but they also fail on the latest commit (autowire.UpickleTests.compilationFailures)