### PR TITLE
Fix for using with scalapb generated rpc's

### DIFF
--- a/autowire/shared/src/main/scala/autowire/Macros.scala
+++ b/autowire/shared/src/main/scala/autowire/Macros.scala
@@ -43,6 +43,7 @@ object Macros {
         if !member.isSynthetic
         if member.isPublic
         if member.isTerm
+        if member.isAbstract
         memTerm = member.asTerm
         if memTerm.isMethod
       } yield {


### PR DESCRIPTION
Filters only abstract members for routing.