### PR TITLE
Server: adds another .route with preCallOp param 

### DIFF
--- a/autowire/shared/src/main/scala/autowire/ClientServer.scala
+++ b/autowire/shared/src/main/scala/autowire/ClientServer.scala
@@ -41,11 +41,18 @@ case class ClientProxy[Trait,
 trait Server[PickleType, Reader[_], Writer[_]] extends Serializers[PickleType, Reader, Writer] {
   type Request = Core.Request[PickleType]
   type Router = Core.Router[PickleType]
+
   /**
    * A macro that generates a `Router` PartialFunction which will dispatch incoming
    * [[Requests]] to the relevant method on [[Trait]]
    */
   def route[Trait](target: Trait): Router = macro Macros.routeMacro[Trait, PickleType]
+
+  /**
+   * A macro that generates a `Router` PartialFunction which will dispatch incoming
+   * [[Requests]] to the relevant method on [[Trait]]
+   */
+  def route[Trait](target: Trait, preCallOp: () => Unit): Router = macro Macros.routeWithPreCallOpMacro[Trait, PickleType]
 
 }
 


### PR DESCRIPTION
preCallOp param allows set contexts in the worker thread.
For example we may set some authorization/authentication info without change the trait for client side.