### PR TITLE
Add Scala Native support

### DIFF
--- a/autowire/shared/src/main/scala-2.12/autowire/ScalaVersionStubs.scala
+++ b/autowire/shared/src/main/scala-2.12/autowire/ScalaVersionStubs.scala
@@ -1,5 +1,0 @@
-package autowire
-
-object ScalaVersionStubs {
-  type compileTimeOnly = scala.annotation.compileTimeOnly
-}

--- a/autowire/shared/src/main/scala-2.13/autowire/ScalaVersionStubs.scala
+++ b/autowire/shared/src/main/scala-2.13/autowire/ScalaVersionStubs.scala
@@ -1,5 +1,0 @@
-package autowire
-
-object ScalaVersionStubs {
-  type compileTimeOnly = scala.annotation.compileTimeOnly
-}

--- a/autowire/shared/src/main/scala/autowire/Internal.scala
+++ b/autowire/shared/src/main/scala/autowire/Internal.scala
@@ -1,9 +1,8 @@
 package autowire
 
-
+import scala.annotation.compileTimeOnly
 import scala.concurrent.Future
 import language.experimental.macros
-
 
 /**
  * Holds a bunch of implementation details, which need to be public
@@ -24,7 +23,7 @@ object Internal{
    * erased completely when the macro-implementation of `.call()` runs
    */
   class ClientCallable[T]{
-    @ScalaVersionStubs.compileTimeOnly(".call() method is synthetic and should not be used directly")
+    @compileTimeOnly(".call() method is synthetic and should not be used directly")
     def call(): Future[T] = macro Macros.clientMacro[T]
   }
 

--- a/autowire/shared/src/main/scala/autowire/package.scala
+++ b/autowire/shared/src/main/scala/autowire/package.scala
@@ -1,5 +1,6 @@
 import autowire.Macros
 
+import scala.annotation.compileTimeOnly
 import scala.concurrent.Future
 import language.experimental.macros
 import acyclic.file
@@ -30,7 +31,7 @@ package object autowire extends autowire.Internal.LowPri {
    * are immediately followed by a `.call()` call
    */
 
-  @ScalaVersionStubs.compileTimeOnly("You have forgotten to append .call() to the end of an autowire call.")
+  @compileTimeOnly("You have forgotten to append .call() to the end of an autowire call.")
   implicit def unwrapClientProxy[Trait, PickleType, Reader[_], Writer[_]]
                                 (w: ClientProxy[Trait, PickleType, Reader, Writer]): Trait = ???
 }

--- a/autowire/shared/src/test/scala/autowire/CompileTimeOnlyTests.scala
+++ b/autowire/shared/src/test/scala/autowire/CompileTimeOnlyTests.scala
@@ -7,7 +7,6 @@ import utest._
 import upickle.default._
 import autowire._
 
-//This test should only be run in 2.11+ since 2.10 will not enforce this annotation
 object CompileTimeOnlyTests extends TestSuite{
   import scala.concurrent.ExecutionContext.Implicits.global
   // client-side implementation, and call-site

--- a/autowire/shared/src/test/scala/autowire/UpickleTests.scala
+++ b/autowire/shared/src/test/scala/autowire/UpickleTests.scala
@@ -110,7 +110,7 @@ object UpickleTests extends TestSuite{
         res2 == "1+2+10",
         res3 == "1+2+10",
         res4 == "1.2*2.3",
-        res5 == "1.1*2.2*3.3*4.4",
+        res5 == "1.1*2.2*3.3*4.4"
      //   res6 == Point(11, 22)
       )
       Bundle.transmitted.last

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ val baseSettings = Seq(
   name := "autowire",
   version := "0.2.7",
   scalaVersion := "2.13.1",
-  crossScalaVersions := Seq("2.12.10", "2.13.1"),
+  crossScalaVersions := Seq("2.12.11", "2.13.1"),
   scmInfo := Some(ScmInfo(
     browseUrl = url("https://github.com/lihaoyi/autowire"),
     connection = "scm:git:git@github.com:lihaoyi/autowire.git"
@@ -19,22 +19,18 @@ val baseSettings = Seq(
   )
 )
 
-val autowire = _root_.sbtcrossproject.CrossPlugin.autoImport.crossProject(JSPlatform, JVMPlatform)
+val acyclicVersion = Def.setting{ if (scalaVersion.value == "2.11.12") "0.1.8" else "0.2.0" }
+
+val autowire = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(baseSettings)
   .settings(
     autoCompilerPlugins := true,
-    addCompilerPlugin("com.lihaoyi" %% "acyclic" % "0.2.0"),
     libraryDependencies ++= Seq(
-      "com.lihaoyi" %% "acyclic" % "0.2.0" % Provided,
+      "com.lihaoyi" %% "acyclic" % acyclicVersion.value % Provided,
+      compilerPlugin("com.lihaoyi" %% "acyclic" % acyclicVersion.value),
       "com.lihaoyi" %%% "utest" % "0.7.4" % Test,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value,
       "com.lihaoyi" %%% "upickle" % "1.0.0" % Test
-    ) ++ (
-      if (!scalaVersion.value.startsWith("2.10.")) Nil
-      else Seq(
-        compilerPlugin("org.scalamacros" % s"paradise" % "2.0.0" cross CrossVersion.full),
-        "org.scalamacros" %% s"quasiquotes" % "2.0.0"
-      )
     ),
     testFrameworks += new TestFramework("utest.runner.Framework"),
     // Sonatype
@@ -43,7 +39,7 @@ val autowire = _root_.sbtcrossproject.CrossPlugin.autoImport.crossProject(JSPlat
 
   ).jsSettings(
       resolvers ++= Seq(
-        "bintray-alexander_myltsev" at "http://dl.bintray.com/content/alexander-myltsev/maven"
+        "bintray-alexander_myltsev" at "https://dl.bintray.com/content/alexander-myltsev/maven"
       ),
       scalaJSStage in Test := FullOptStage,
       scalacOptions += {
@@ -55,11 +51,12 @@ val autowire = _root_.sbtcrossproject.CrossPlugin.autoImport.crossProject(JSPlat
         s"-P:scalajs:mapSourceURI:$a->$g/"
       }
   ).jvmSettings(
-    resolvers += "Typesafe Repo" at "http://repo.typesafe.com/typesafe/releases/",
+    resolvers += "Typesafe Repo" at "https://repo.typesafe.com/typesafe/releases/",
     libraryDependencies ++= Seq(
       "com.esotericsoftware" % "kryo" % "5.0.0-RC5" % Test
     )
+  ).nativeSettings(
+    scalaVersion := "2.11.12",
+    crossScalaVersions := Seq("2.11.12"),
+    nativeLinkStubs := true
   )
-
-lazy val autowireJS = autowire.js
-lazy val autowireJVM = autowire.jvm

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.9
+sbt.version=1.3.10

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,5 +1,9 @@
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.1")
 
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.0-M2")
+
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
+
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.0.0")


### PR DESCRIPTION
- Remove Scala 2.10 support parts
- Use @compileTimeOnly directly
- Bump Sbt to 1.3.10
- Bump Scala 2.12 to 2.12.11